### PR TITLE
Docker部署更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM node:slim
-RUN touch /etc/apt/sources.list && sed -i 's/deb.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
-RUN sed -i 's/security.debian.org/mirrors.ustc.edu.cn/g' /etc/apt/sources.list && apt update
-RUN chmod 777 /usr/local/
 WORKDIR /usr/local
 EXPOSE 4174 4175
 ENV WS_SERVER_ADDR=0.0.0.0 WS_SERVER_PORT=4174 WEB_PORT=4175
-RUN apt install git -y
-RUN npm i yarn -g --force \
-	&& yarn config set registry https://registry.npmmirror.com/ \
-	&& git clone https://github.com/paotuan/qqchannel-bot.git \
- 	&& cd qqchannel-bot && yarn install
+RUN sed -i "s@http://\(deb\|security\).debian.org@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/debian.sources && \
+apt-get update && chmod 777 /usr/local/ && \
+apt-get install -y git && \
+npm i yarn -g --force \
+&& yarn config set registry https://registry.npmmirror.com/ \
+&& git clone https://github.com/paotuan/qqchannel-bot.git \
+&& cd qqchannel-bot && yarn install
 ENTRYPOINT cd qqchannel-bot && echo -e "WS_SERVER_ADDR=$WS_SERVER_ADDR\nWS_SERVER_PORT=$WS_SERVER_PORT\nWEB_PORT=$WEB_PORT">>.env \
 	&& yarn run build && yarn global add pm2 \
 	&& cd dist && yarn install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM node:slim
 WORKDIR /usr/local
 EXPOSE 4174 4175
 ENV WS_SERVER_ADDR=0.0.0.0 WS_SERVER_PORT=4174 WEB_PORT=4175
-RUN sed -i "s@http://\(deb\|security\).debian.org@http://mirrors.aliyun.com@g" /etc/apt/sources.list.d/debian.sources && \
-apt-get update && chmod 777 /usr/local/ && \
-apt-get install -y git && \
-npm i yarn -g --force \
-&& yarn config set registry https://registry.npmmirror.com/ \
-&& git clone https://github.com/paotuan/qqchannel-bot.git \
-&& cd qqchannel-bot && yarn install
+COPY . qqchannel-bot/
+RUN apt-get update && chmod 777 /usr/local/ && \
+npm i yarn -g --force && \
+yarn config set registry https://registry.npmmirror.com/ && \
+cd qqchannel-bot && yarn install
 ENTRYPOINT cd qqchannel-bot && echo -e "WS_SERVER_ADDR=$WS_SERVER_ADDR\nWS_SERVER_PORT=$WS_SERVER_PORT\nWEB_PORT=$WEB_PORT">>.env \
 	&& yarn run build && yarn global add pm2 \
 	&& cd dist && yarn install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /usr/local
 EXPOSE 4174 4175
 ENV WS_SERVER_ADDR=0.0.0.0 WS_SERVER_PORT=4174 WEB_PORT=4175
 COPY . qqchannel-bot/
-RUN apt-get update && chmod 777 /usr/local/ && \
+RUN chmod 777 /usr/local/ && \
 npm i yarn -g --force && \
 yarn config set registry https://registry.npmmirror.com/ && \
 cd qqchannel-bot && yarn install

--- a/README.md
+++ b/README.md
@@ -21,47 +21,11 @@
 
 你可以在 [releases 页面](https://github.com/paotuan/qqchannel-bot/releases) 找到所有的历史版本。
 
+### Docker 部署
+请参考 [Docker 部署](https://paotuan.io/setup/download/docker.html)
+
 ### 服务器部署
-请参考 [Linux 部署](https://paotuan.io/setup/download/linux.html)
-
-### Docker部署
-
-
-#### 1.拉取镜像运行  
-1)拉取镜像 
-```
-docker pull monthwolf/paotuan:latest
-```
-
-2)运行  
-快速启动（请务必填写主机IP，否则可能会出现无法连接到后端的情况）
-```
-docker run -d --net=host \
--e WS_SERVER_ADDR=你的主机IP \
---name paotuan monthwolf/paotuan:latest
-```  
-
-自定义端口
-```
-docker run -d --net=host \
--e WS_SERVER_ADDR=你的主机IP \
--e WS_SERVER_PORT=端口1 \
--e WEB_PORT=端口2 \
---name paotuan monthwolf/paotuan:latest
-```  
-
-#### 2.自构建镜像部署
-1)脚本部署 **(推荐)**  
-下载项目中的build.sh脚本，给予权限并运行
-```bash
-chmod 777 build.sh
-./build.sh #运行后根据提示输入信息构建镜像，并自行选择是否直接启动
-```
-
-
-2)通过dockerfile文件部署  
-将整个项目源码拷贝至本地环境中，解压后，进入项目文件夹并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
-dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
+可以从源码部署，请参考 [Linux 部署](https://paotuan.io/setup/download/linux.html)
 
 ### 本地开发
 require Node >= 14.18

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### Docker部署
 #### 1.通过dockerfile文件部署
-将dockerfile拷贝至本地环境中，并在该路径下运行命令`docker build paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
+将dockerfile拷贝至本地环境中，并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
 dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
 
 #### 2.拉取镜像运行  

--- a/README.md
+++ b/README.md
@@ -21,11 +21,36 @@
 
 你可以在 [releases 页面](https://github.com/paotuan/qqchannel-bot/releases) 找到所有的历史版本。
 
-### Docker 部署
-请参考 [Docker 部署](https://paotuan.io/setup/download/docker.html)
-
 ### 服务器部署
-可以从源码部署，请参考 [Linux 部署](https://paotuan.io/setup/download/linux.html)
+请参考 [Linux 部署](https://paotuan.io/setup/download/linux.html)
+
+### Docker部署
+#### 1.通过dockerfile文件部署
+将dockerfile拷贝至本地环境中，并在该路径下运行命令`docker build paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
+dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
+
+#### 2.拉取镜像运行  
+1)拉取镜像 
+```
+docker pull monthwolf/paotuan:latest
+```
+
+2)运行  
+快速启动（请务必填写主机IP，否则可能会出现无法连接到后端的情况）
+```
+docker run -d --net=host \
+-e WS_SERVER_ADDR=你的主机IP \
+--name paotuan monthwolf/paotuan:latest
+```  
+
+自定义端口
+```
+docker run -d --net=host \
+-e WS_SERVER_ADDR=你的主机IP \
+-e WS_SERVER_PORT=端口1 \
+-e WEB_PORT=端口2 \
+--name paotuan monthwolf/paotuan:latest
+```  
 
 ### 本地开发
 require Node >= 14.18

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ### Docker部署
 #### 1.通过dockerfile文件部署
-将dockerfile拷贝至本地环境中，并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
+将[Dockerfile](https://raw.githubusercontent.com/monthwolf/qqchannel-bot/master/Dockerfile)拷贝至本地环境中，并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
 dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
 
 #### 2.拉取镜像运行  

--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@
 请参考 [Linux 部署](https://paotuan.io/setup/download/linux.html)
 
 ### Docker部署
-#### 1.通过dockerfile文件部署
-将[Dockerfile](https://raw.githubusercontent.com/monthwolf/qqchannel-bot/master/Dockerfile)拷贝至本地环境中，并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
-dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
 
-#### 2.拉取镜像运行  
+
+#### 1.拉取镜像运行  
 1)拉取镜像 
 ```
 docker pull monthwolf/paotuan:latest
@@ -51,6 +49,19 @@ docker run -d --net=host \
 -e WEB_PORT=端口2 \
 --name paotuan monthwolf/paotuan:latest
 ```  
+
+#### 2.自构建镜像部署
+1)脚本部署 **(推荐)**  
+下载项目中的build.sh脚本，给予权限并运行
+```bash
+chmod 777 build.sh
+./build.sh #运行后根据提示输入信息构建镜像，并自行选择是否直接启动
+```
+
+
+2)通过dockerfile文件部署  
+将整个项目源码拷贝至本地环境中，解压后，进入项目文件夹并在该路径下运行命令`docker build -t paotuan:latest .`编译镜像文件(注意命令结尾的 **.** 不要漏掉)  
+dockerfile文件可以自行修改再编译，编译的镜像参考 **方式二** 命令运行,只需要把`monthwolf/paotuan:latest`改成`paotuan:latest`
 
 ### 本地开发
 require Node >= 14.18

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+read -p "请输入版本号(请复制完全,前面的v也需要带):" version
+url="https://github.com/paotuan/qqchannel-bot/archive/refs/tags/$version.zip"
+wget $url
+version=${version:1}
+filename=$(basename $url)
+unzip $filename
+cd qqchannel-bot-$version
+read -p "请输入构建镜像的名称(建议带dockerhub用户名,方便push,如monthwolf/paotuan):" image
+read -p "请输入构建镜像的tag(默认与版本号一致):" tag
+#如果tag为空则设为版本号
+if [ -z "$tag" ];then
+    tag=$version
+fi
+dockertag=$image:$tag
+echo "正在构建$dockertag"
+docker build -t $dockertag .
+#删除解压文件夹和下载文件
+cd ..
+echo "构建完成!正在删除文件夹和下载文件..."
+rm -rf qqchannel-bot-$version $filename
+#询问是否运行容器
+read -p "删除完成!是否运行容器(y/n):" run
+if [ $run == "y" ];then
+    read -p "请输入IP(默认0.0.0.0,不输入即为默认值):" ip
+    ip=${ip:-0.0.0.0}
+    read -p "请输入第一个端口号(默认4174):" port1
+    read -p "请输入第二个端口号(默认4175):" port2
+    port1=${port1:-4174}
+    port2=${port2:-4175}
+    docker run -d --net=host \
+    -e WS_SERVER_ADDR=$ip \
+    -e WS_SERVER_PORT=$port1 \
+    -e WEB_PORT=$port2 \
+    --name paotuan $dockertag
+else
+    echo "已退出"
+fi


### PR DESCRIPTION
之前的docker镜像只能拉取当前主支进行构建，于是修改了一下，对多版本进行了支持
添加了一个适用于Linux的多版本docker镜像构建脚本，同步更新了dockerfile文件以及docker构建说明